### PR TITLE
Make the README example code more portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import os
 from kubernetes import client, config
 
 # Configs can be set in Configuration class directly or using helper utility
-config.load_kube_config(os.environ["HOME"] + '/.kube/config')
+config.load_kube_config(os.path.join(os.path.expanduser('~'), '.kube', 'config')
 
 v1=client.CoreV1Api()
 print("Listing pods with their IPs:")
@@ -48,7 +48,7 @@ import os
 from kubernetes import client, config, watch
 
 # Configs can be set in Configuration class directly or using helper utility
-config.load_kube_config(os.environ["HOME"] + '/.kube/config')
+config.load_kube_config(os.path.join(os.path.expanduser('~'), '.kube', 'config')
 
 v1 = client.CoreV1Api()
 count = 10

--- a/examples/example1.py
+++ b/examples/example1.py
@@ -20,7 +20,7 @@ from kubernetes import client, config
 def main():
     # Configs can be set in Configuration class directly or using helper
     # utility
-    config.load_kube_config(os.environ["HOME"] + '/.kube/config')
+    config.load_kube_config(os.path.join(os.path.expanduser('~'), '.kube', 'config')
 
     v1 = client.CoreV1Api()
     print("Listing pods with their IPs:")

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -20,7 +20,7 @@ from kubernetes import client, config, watch
 def main():
     # Configs can be set in Configuration class directly or using helper
     # utility
-    config.load_kube_config(os.environ["HOME"] + '/.kube/config')
+    config.load_kube_config(os.path.join(os.path.expanduser('~'), '.kube', 'config')
 
     v1 = client.CoreV1Api()
     count = 10

--- a/examples/example3.py
+++ b/examples/example3.py
@@ -20,7 +20,7 @@ from kubernetes import client, config
 def main():
     # Configs can be set in Configuration class directly or using helper
     # utility
-    config.load_kube_config(os.environ["HOME"] + '/.kube/config')
+    config.load_kube_config(os.path.join(os.path.expanduser('~'), '.kube', 'config')
 
     print("Supported APIs (* is preferred version):")
     print("%-20s %s" %


### PR DESCRIPTION
Also, the `$HOME` variable can be modified while `os.path.expanduser()` does the right thing.

This works on windows as well whereas the previous code did not.