### PR TITLE
Add default kube config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,10 @@ pip install kubernetes
 list all pods:
 
 ```python
-import os
-
 from kubernetes import client, config
 
 # Configs can be set in Configuration class directly or using helper utility
-config.load_kube_config(os.path.join(os.path.expanduser('~'), '.kube', 'config'))
+config.load_kube_config()
 
 v1=client.CoreV1Api()
 print("Listing pods with their IPs:")
@@ -44,12 +42,10 @@ for i in ret.items:
 watch on namespace object:
 
 ```python
-import os
-
 from kubernetes import client, config, watch
 
 # Configs can be set in Configuration class directly or using helper utility
-config.load_kube_config(os.path.join(os.path.expanduser('~'), '.kube', 'config'))
+config.load_kube_config()
 
 v1 = client.CoreV1Api()
 count = 10

--- a/examples/example1.py
+++ b/examples/example1.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from kubernetes import client, config
 
 
 def main():
     # Configs can be set in Configuration class directly or using helper
-    # utility
-    config.load_kube_config(
-        os.path.join(os.path.expanduser('~'), '.kube', 'config'))
+    # utility. If no argument provided, the config will be loaded from
+    # default location.
+    config.load_kube_config()
 
     v1 = client.CoreV1Api()
     print("Listing pods with their IPs:")

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from kubernetes import client, config, watch
 
 
 def main():
     # Configs can be set in Configuration class directly or using helper
-    # utility
-    config.load_kube_config(
-        os.path.join(os.path.expanduser('~'), '.kube', 'config'))
+    # utility. If no argument provided, the config will be loaded from
+    # default location.
+    config.load_kube_config()
 
     v1 = client.CoreV1Api()
     count = 10

--- a/examples/example3.py
+++ b/examples/example3.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from kubernetes import client, config
 
 
 def main():
     # Configs can be set in Configuration class directly or using helper
-    # utility
-    config.load_kube_config(
-        os.path.join(os.path.expanduser('~'), '.kube', 'config'))
+    # utility. If no argument provided, the config will be loaded from
+    # default location.
+    config.load_kube_config()
 
     print("Supported APIs (* is preferred version):")
     print("%-20s %s" %

--- a/examples/example4.py
+++ b/examples/example4.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from kubernetes import client, config
 from kubernetes.client import configuration
 
 
 def main():
-    config_file = os.path.join(os.path.expanduser('~'), '.kube', 'config')
-    contexts, active_context = config.list_kube_config_contexts(config_file)
+    contexts, active_context = config.list_kube_config_contexts()
     if not contexts:
         print("Cannot find any context in kube-config file.")
         return
@@ -43,7 +40,7 @@ def main():
 
     # Configs can be set in Configuration class directly or using helper
     # utility
-    config.load_kube_config(config_file, context_name)
+    config.load_kube_config(context=context_name)
 
     print("Active host is %s" % configuration.host)
 

--- a/kubernetes/config/kube_config.py
+++ b/kubernetes/config/kube_config.py
@@ -24,6 +24,7 @@ from oauth2client.client import GoogleCredentials
 
 from .config_exception import ConfigException
 
+KUBE_CONFIG_DEFAULT_LOCATION = '~/.kube/config'
 _temp_files = {}
 
 
@@ -269,12 +270,16 @@ def _get_kube_config_loader_for_yaml_file(filename, **kwargs):
             **kwargs)
 
 
-def list_kube_config_contexts(config_file):
+def list_kube_config_contexts(config_file=None):
+
+    if config_file is None:
+        config_file = os.path.expanduser(KUBE_CONFIG_DEFAULT_LOCATION)
+
     loader = _get_kube_config_loader_for_yaml_file(config_file)
     return loader.list_contexts(), loader.current_context
 
 
-def load_kube_config(config_file, context=None):
+def load_kube_config(config_file=None, context=None):
     """Loads authentication and cluster information from kube-config file
     and stores them in kubernetes.client.configuration.
 
@@ -282,6 +287,9 @@ def load_kube_config(config_file, context=None):
     :param context: set the active context. If is set to None, current_context
     from config file will be used.
     """
+
+    if config_file is None:
+        config_file = os.path.expanduser(KUBE_CONFIG_DEFAULT_LOCATION)
 
     _get_kube_config_loader_for_yaml_file(
         config_file, active_context=context).load_and_set()

--- a/kubernetes/config/kube_config_test.py
+++ b/kubernetes/config/kube_config_test.py
@@ -20,7 +20,7 @@ import unittest
 
 from .config_exception import ConfigException
 from .kube_config import (ConfigNode, FileOrData, KubeConfigLoader,
-                          _create_temp_file_with_content, _cleanup_temp_files)
+                          _cleanup_temp_files, _create_temp_file_with_content)
 
 NON_EXISTING_FILE = "zz_non_existing_file_472398324"
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -9,8 +9,7 @@
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and 
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 # Intentional empty init file to make this folder a python package
-


### PR DESCRIPTION
`kubenetes.config.load_config` needs the location of config file to load it. We can set the location to the default location of ~/.kube/config.