### PR TITLE
Bugfix: Python client does not resolve relative paths in kubeconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-# current-version
+# v1.0.0-beta1
 
-- Add context switch to kube config loader
-- Test coverage improvments
+- Add context switch to kube config loader #46 
+- Add default kube config location #64
+- Bugfix: Python client does not resolve relative paths in kubeconfig #68
+- Bugfix: `read_namespaced_pod_log` get None response #57
+- Improved test coverage #54
+- Improved client generator #49
 
 # v1.0.0-alpha2
 


### PR DESCRIPTION
Resolving relative paths based on cube config file path.

Fixes #68 