### PR TITLE
Kubernetes is not a valid value for Environment classifier in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
     """,
     classifiers=[
         "Development Status :: %s" % DEVELOPMENT_STATUS,
-        "Environment :: Kubernetes",
         "Topic :: Utilities",
         "Intended Audience :: Developers",
         "Intended Audience :: Information Technology",


### PR DESCRIPTION
Release 1.0.0a5 failed because of this.