### PR TITLE
Fix for patch_* to work

### DIFF
--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -146,7 +146,18 @@ class RESTClientObject(object):
             if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
                 if query_params:
                     url += '?' + urlencode(query_params)
-                if re.search('json', headers['Content-Type'], re.IGNORECASE):
+                if headers['Content-Type'] == 'application/json-patch+json':
+                    headers[
+                        'Content-Type'] = 'application/strategic-merge-patch+json'
+                    request_body = None
+                    if body:
+                        request_body = json.dumps(body)
+                    r = self.pool_manager.request(method, url,
+                                                  body=request_body,
+                                                  preload_content=_preload_content,
+                                                  timeout=timeout,
+                                                  headers=headers)
+                elif re.search('json', headers['Content-Type'], re.IGNORECASE):
                     request_body = None
                     if body:
                         request_body = json.dumps(body)

--- a/kubernetes/e2e_test/test_client.py
+++ b/kubernetes/e2e_test/test_client.py
@@ -105,17 +105,15 @@ class TestClient(unittest.TestCase):
         self.assertEqual('frontend', resp.metadata.name)
         self.assertTrue(resp.status)
 
-        # TODO(dims) : Fails with "json: cannot unmarshal object into
-        # Go value of type jsonpatch.Patch"
-        # service_manifest['spec']['ports'] = [{'name': 'new',
-        #                                       'port': 8080,
-        #                                       'protocol': 'TCP',
-        #                                       'targetPort': 8080}]
-        # resp = api.patch_namespaced_service(body=service_manifest,
-        #                                     name='frontend',
-        #                                     namespace='default')
-        # self.assertEqual(2, len(resp.spec.ports))
-        # self.assertTrue(resp.status)
+        service_manifest['spec']['ports'] = [{'name': 'new',
+                                              'port': 8080,
+                                              'protocol': 'TCP',
+                                              'targetPort': 8080}]
+        resp = api.patch_namespaced_service(body=service_manifest,
+                                            name='frontend',
+                                            namespace='default')
+        self.assertEqual(2, len(resp.spec.ports))
+        self.assertTrue(resp.status)
 
         resp = api.delete_namespaced_service(name='frontend',
                                              namespace='default')
@@ -182,11 +180,9 @@ class TestClient(unittest.TestCase):
             name='test-configmap', namespace='default')
         self.assertEqual('test-configmap', resp.metadata.name)
 
-        # TODO(dims): Fails with "json: cannot unmarshal object
-        # into Go value of type jsonpatch.Patch"
-        # test_configmap['data']['config.json'] = "{}"
-        # resp = api.patch_namespaced_config_map(
-        #     name='test-configmap', namespace='default', body=test_configmap)
+        test_configmap['data']['config.json'] = "{}"
+        resp = api.patch_namespaced_config_map(
+            name='test-configmap', namespace='default', body=test_configmap)
 
         resp = api.delete_namespaced_config_map(
             name='test-configmap', body={}, namespace='default')


### PR DESCRIPTION
Hack to get patch_namespaced_config_map and patch_namespaced_service
etc to work by essentially switching over the content-type from:
application/json-patch+json
to:
application/strategic-merge-patch+json

Fixes #93