### PR TITLE
Revert "Automated cherry pick of #183"

### DIFF
--- a/kubernetes/config/kube_config.py
+++ b/kubernetes/config/kube_config.py
@@ -59,18 +59,14 @@ class FileOrData(object):
      content of obj[%file_key_name] and represent it as file or data.
      Note that the data is preferred. The obj[%file_key_name] will be used iff
      obj['%data_key_name'] is not set or empty. Assumption is file content is
-     raw data and data field is base64 string. The assumption can be changed
-     with base64_file_content flag. If set to False, the content of the file
-     will assumed to be base64 and read as is. The default True value will
-     result in base64 encode of the file content after read."""
+     raw data and data field is base64 string."""
 
     def __init__(self, obj, file_key_name, data_key_name=None,
-                 file_base_path="", base64_file_content=True):
+                 file_base_path=""):
         if not data_key_name:
             data_key_name = file_key_name + "-data"
         self._file = None
         self._data = None
-        self._base64_file_content = base64_file_content
         if data_key_name in obj:
             self._data = obj[data_key_name]
         elif file_key_name in obj:
@@ -82,11 +78,8 @@ class FileOrData(object):
         decoded obj[%data_key_name] content otherwise obj[%file_key_name]."""
         use_data_if_no_file = not self._file and self._data
         if use_data_if_no_file:
-            if self._base64_file_content:
-                self._file = _create_temp_file_with_content(
-                    base64.decodestring(self._data.encode()))
-            else:
-                self._file = _create_temp_file_with_content(self._data)
+            self._file = _create_temp_file_with_content(
+                base64.decodestring(self._data.encode()))
         if self._file and not os.path.isfile(self._file):
             raise ConfigException("File does not exists: %s" % self._file)
         return self._file
@@ -97,11 +90,8 @@ class FileOrData(object):
         use_file_if_no_data = not self._data and self._file
         if use_file_if_no_data:
             with open(self._file) as f:
-                if self._base64_file_content:
-                    self._data = bytes.decode(
-                        base64.encodestring(str.encode(f.read())))
-                else:
-                    self._data = f.read()
+                self._data = bytes.decode(
+                    base64.encodestring(str.encode(f.read())))
         return self._data
 
 
@@ -174,8 +164,7 @@ class KubeConfigLoader(object):
     def _load_user_token(self):
         token = FileOrData(
             self._user, 'tokenFile', 'token',
-            file_base_path=self._config_base_path,
-            base64_file_content=False).as_data()
+            file_base_path=self._config_base_path).as_data()
         if token:
             self.token = "Bearer %s" % token
             return True

--- a/kubernetes/config/kube_config_test.py
+++ b/kubernetes/config/kube_config_test.py
@@ -108,12 +108,6 @@ class TestFileOrData(BaseTestCase):
                        data_key_name=TEST_DATA_KEY)
         self.assertEqual(TEST_DATA, self.get_file_content(t.as_file()))
 
-    def test_file_given_data_no_base64(self):
-        obj = {TEST_DATA_KEY: TEST_DATA}
-        t = FileOrData(obj=obj, file_key_name=TEST_FILE_KEY,
-                       data_key_name=TEST_DATA_KEY, base64_file_content=False)
-        self.assertEqual(TEST_DATA, self.get_file_content(t.as_file()))
-
     def test_data_given_data(self):
         obj = {TEST_DATA_KEY: TEST_DATA_BASE64}
         t = FileOrData(obj=obj, file_key_name=TEST_FILE_KEY,
@@ -125,13 +119,6 @@ class TestFileOrData(BaseTestCase):
             TEST_FILE_KEY: self._create_temp_file(content=TEST_DATA)}
         t = FileOrData(obj=obj, file_key_name=TEST_FILE_KEY)
         self.assertEqual(TEST_DATA_BASE64, t.as_data())
-
-    def test_data_given_file_no_base64(self):
-        obj = {
-            TEST_FILE_KEY: self._create_temp_file(content=TEST_DATA)}
-        t = FileOrData(obj=obj, file_key_name=TEST_FILE_KEY,
-                       base64_file_content=False)
-        self.assertEqual(TEST_DATA, t.as_data())
 
     def test_data_given_file_and_data(self):
         obj = {
@@ -575,7 +562,7 @@ class TestKubeConfigLoader(BaseTestCase):
             with open(os.path.join(temp_dir, "client_key"), "wb") as fd:
                 fd.write(TEST_CLIENT_KEY.encode())
             with open(os.path.join(temp_dir, "token_file"), "wb") as fd:
-                fd.write(TEST_DATA_BASE64.encode())
+                fd.write(TEST_DATA.encode())
             KubeConfigLoader(
                 config_dict=self.TEST_KUBE_CONFIG,
                 active_context="ssl-local-file",


### PR DESCRIPTION
Reverts kubernetes-incubator/client-python#189

Backward incompatible change. Will include this bugfix only in 2.0x releases.