### PR TITLE
Exclude urllib3 version 1.21 from depedencies as it breaks our code

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi>=14.05.14 # MPL
 six>=1.9.0  # MIT
 python-dateutil>=2.5.3  # BSD
 setuptools>=21.0.0  # PSF/ZPL
-urllib3>=1.19.1  # MIT
+urllib3>=1.19.1,!=1.21  # MIT
 pyyaml>=3.12  # MIT
 oauth2client>=4.0.0  # Apache-2.0
 ipaddress>=1.0.17  # PSF

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ REQUIRES = [
     "oauth2client",
     "setuptools",
     "six",
-    "urllib3",
+    "urllib3!=1.21",
     "python-dateutil",
     "pyyaml",
     "websocket-client",


### PR DESCRIPTION
ref: https://github.com/kubernetes-incubator/client-python/issues/197

Look like the problem is going away after 1.21 because of this patch: https://github.com/shazow/urllib3/pull/1157

so we should be fine with versions > 1.21