### PR TITLE
fix for #187 failure when using RFC 6902 json-patch operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.0.0b2
+- Bugfix: support RFC6902 'json-patch' operations #187
+
 # v1.0.1
 - Bugfix: urllib3 1.21 fails tests, Excluding version 1.21 from dependencies #197
 

--- a/kubernetes/client/rest.py
+++ b/kubernetes/client/rest.py
@@ -154,8 +154,8 @@ class RESTClientObject(object):
                 if query_params:
                     url += '?' + urlencode(query_params)
                 if headers['Content-Type'] == 'application/json-patch+json':
-                    headers[
-                        'Content-Type'] = 'application/strategic-merge-patch+json'
+                    if not isinstance(body, list):
+                        headers['Content-Type'] = 'application/strategic-merge-patch+json'
                     request_body = None
                     if body:
                         request_body = json.dumps(body)


### PR DESCRIPTION
My solution to the issue assumes a body containing a JSON array to be a RFC 6902 'json-patch' operation because this RFC requires an array of operations.  The existing code already assumes the use of 'strategic-merge-patch' (Kubernetes preferred) instead of the RFC 7386 'merge-patch', so I left that behavior as is.