### PR TITLE
Switch to stable release of swagger-codegen

### DIFF
--- a/kubernetes/client/models/apps_v1beta1_deployment.py
+++ b/kubernetes/client/models/apps_v1beta1_deployment.py
@@ -209,6 +209,9 @@ class AppsV1beta1Deployment(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, AppsV1beta1Deployment):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/apps_v1beta1_deployment_condition.py
+++ b/kubernetes/client/models/apps_v1beta1_deployment_condition.py
@@ -239,6 +239,9 @@ class AppsV1beta1DeploymentCondition(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, AppsV1beta1DeploymentCondition):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/apps_v1beta1_deployment_list.py
+++ b/kubernetes/client/models/apps_v1beta1_deployment_list.py
@@ -185,6 +185,9 @@ class AppsV1beta1DeploymentList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, AppsV1beta1DeploymentList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/apps_v1beta1_deployment_rollback.py
+++ b/kubernetes/client/models/apps_v1beta1_deployment_rollback.py
@@ -213,6 +213,9 @@ class AppsV1beta1DeploymentRollback(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, AppsV1beta1DeploymentRollback):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/apps_v1beta1_deployment_spec.py
+++ b/kubernetes/client/models/apps_v1beta1_deployment_spec.py
@@ -315,6 +315,9 @@ class AppsV1beta1DeploymentSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, AppsV1beta1DeploymentSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/apps_v1beta1_deployment_status.py
+++ b/kubernetes/client/models/apps_v1beta1_deployment_status.py
@@ -261,6 +261,9 @@ class AppsV1beta1DeploymentStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, AppsV1beta1DeploymentStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/apps_v1beta1_deployment_strategy.py
+++ b/kubernetes/client/models/apps_v1beta1_deployment_strategy.py
@@ -131,6 +131,9 @@ class AppsV1beta1DeploymentStrategy(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, AppsV1beta1DeploymentStrategy):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/apps_v1beta1_rollback_config.py
+++ b/kubernetes/client/models/apps_v1beta1_rollback_config.py
@@ -105,6 +105,9 @@ class AppsV1beta1RollbackConfig(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, AppsV1beta1RollbackConfig):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/apps_v1beta1_rolling_update_deployment.py
+++ b/kubernetes/client/models/apps_v1beta1_rolling_update_deployment.py
@@ -131,6 +131,9 @@ class AppsV1beta1RollingUpdateDeployment(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, AppsV1beta1RollingUpdateDeployment):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/apps_v1beta1_scale.py
+++ b/kubernetes/client/models/apps_v1beta1_scale.py
@@ -209,6 +209,9 @@ class AppsV1beta1Scale(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, AppsV1beta1Scale):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/apps_v1beta1_scale_spec.py
+++ b/kubernetes/client/models/apps_v1beta1_scale_spec.py
@@ -105,6 +105,9 @@ class AppsV1beta1ScaleSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, AppsV1beta1ScaleSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/apps_v1beta1_scale_status.py
+++ b/kubernetes/client/models/apps_v1beta1_scale_status.py
@@ -159,6 +159,9 @@ class AppsV1beta1ScaleStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, AppsV1beta1ScaleStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/extensions_v1beta1_deployment.py
+++ b/kubernetes/client/models/extensions_v1beta1_deployment.py
@@ -209,6 +209,9 @@ class ExtensionsV1beta1Deployment(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, ExtensionsV1beta1Deployment):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/extensions_v1beta1_deployment_condition.py
+++ b/kubernetes/client/models/extensions_v1beta1_deployment_condition.py
@@ -239,6 +239,9 @@ class ExtensionsV1beta1DeploymentCondition(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, ExtensionsV1beta1DeploymentCondition):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/extensions_v1beta1_deployment_list.py
+++ b/kubernetes/client/models/extensions_v1beta1_deployment_list.py
@@ -185,6 +185,9 @@ class ExtensionsV1beta1DeploymentList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, ExtensionsV1beta1DeploymentList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/extensions_v1beta1_deployment_rollback.py
+++ b/kubernetes/client/models/extensions_v1beta1_deployment_rollback.py
@@ -213,6 +213,9 @@ class ExtensionsV1beta1DeploymentRollback(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, ExtensionsV1beta1DeploymentRollback):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/extensions_v1beta1_deployment_spec.py
+++ b/kubernetes/client/models/extensions_v1beta1_deployment_spec.py
@@ -315,6 +315,9 @@ class ExtensionsV1beta1DeploymentSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, ExtensionsV1beta1DeploymentSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/extensions_v1beta1_deployment_status.py
+++ b/kubernetes/client/models/extensions_v1beta1_deployment_status.py
@@ -261,6 +261,9 @@ class ExtensionsV1beta1DeploymentStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, ExtensionsV1beta1DeploymentStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/extensions_v1beta1_deployment_strategy.py
+++ b/kubernetes/client/models/extensions_v1beta1_deployment_strategy.py
@@ -131,6 +131,9 @@ class ExtensionsV1beta1DeploymentStrategy(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, ExtensionsV1beta1DeploymentStrategy):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/extensions_v1beta1_rollback_config.py
+++ b/kubernetes/client/models/extensions_v1beta1_rollback_config.py
@@ -105,6 +105,9 @@ class ExtensionsV1beta1RollbackConfig(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, ExtensionsV1beta1RollbackConfig):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/extensions_v1beta1_rolling_update_deployment.py
+++ b/kubernetes/client/models/extensions_v1beta1_rolling_update_deployment.py
@@ -131,6 +131,9 @@ class ExtensionsV1beta1RollingUpdateDeployment(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, ExtensionsV1beta1RollingUpdateDeployment):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/extensions_v1beta1_scale.py
+++ b/kubernetes/client/models/extensions_v1beta1_scale.py
@@ -209,6 +209,9 @@ class ExtensionsV1beta1Scale(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, ExtensionsV1beta1Scale):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/extensions_v1beta1_scale_spec.py
+++ b/kubernetes/client/models/extensions_v1beta1_scale_spec.py
@@ -105,6 +105,9 @@ class ExtensionsV1beta1ScaleSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, ExtensionsV1beta1ScaleSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/extensions_v1beta1_scale_status.py
+++ b/kubernetes/client/models/extensions_v1beta1_scale_status.py
@@ -159,6 +159,9 @@ class ExtensionsV1beta1ScaleStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, ExtensionsV1beta1ScaleStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/runtime_raw_extension.py
+++ b/kubernetes/client/models/runtime_raw_extension.py
@@ -107,6 +107,9 @@ class RuntimeRawExtension(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, RuntimeRawExtension):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_affinity.py
+++ b/kubernetes/client/models/v1_affinity.py
@@ -157,6 +157,9 @@ class V1Affinity(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Affinity):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_api_group.py
+++ b/kubernetes/client/models/v1_api_group.py
@@ -241,6 +241,9 @@ class V1APIGroup(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1APIGroup):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_api_group_list.py
+++ b/kubernetes/client/models/v1_api_group_list.py
@@ -159,6 +159,9 @@ class V1APIGroupList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1APIGroupList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_api_resource.py
+++ b/kubernetes/client/models/v1_api_resource.py
@@ -217,6 +217,9 @@ class V1APIResource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1APIResource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_api_resource_list.py
+++ b/kubernetes/client/models/v1_api_resource_list.py
@@ -187,6 +187,9 @@ class V1APIResourceList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1APIResourceList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_api_versions.py
+++ b/kubernetes/client/models/v1_api_versions.py
@@ -187,6 +187,9 @@ class V1APIVersions(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1APIVersions):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_attached_volume.py
+++ b/kubernetes/client/models/v1_attached_volume.py
@@ -135,6 +135,9 @@ class V1AttachedVolume(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1AttachedVolume):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_aws_elastic_block_store_volume_source.py
+++ b/kubernetes/client/models/v1_aws_elastic_block_store_volume_source.py
@@ -185,6 +185,9 @@ class V1AWSElasticBlockStoreVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1AWSElasticBlockStoreVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_azure_disk_volume_source.py
+++ b/kubernetes/client/models/v1_azure_disk_volume_source.py
@@ -213,6 +213,9 @@ class V1AzureDiskVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1AzureDiskVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_azure_file_volume_source.py
+++ b/kubernetes/client/models/v1_azure_file_volume_source.py
@@ -161,6 +161,9 @@ class V1AzureFileVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1AzureFileVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_binding.py
+++ b/kubernetes/client/models/v1_binding.py
@@ -185,6 +185,9 @@ class V1Binding(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Binding):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_capabilities.py
+++ b/kubernetes/client/models/v1_capabilities.py
@@ -131,6 +131,9 @@ class V1Capabilities(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Capabilities):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_ceph_fs_volume_source.py
+++ b/kubernetes/client/models/v1_ceph_fs_volume_source.py
@@ -237,6 +237,9 @@ class V1CephFSVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1CephFSVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_cinder_volume_source.py
+++ b/kubernetes/client/models/v1_cinder_volume_source.py
@@ -159,6 +159,9 @@ class V1CinderVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1CinderVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_component_condition.py
+++ b/kubernetes/client/models/v1_component_condition.py
@@ -187,6 +187,9 @@ class V1ComponentCondition(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ComponentCondition):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_component_status.py
+++ b/kubernetes/client/models/v1_component_status.py
@@ -183,6 +183,9 @@ class V1ComponentStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ComponentStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_component_status_list.py
+++ b/kubernetes/client/models/v1_component_status_list.py
@@ -185,6 +185,9 @@ class V1ComponentStatusList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ComponentStatusList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_config_map.py
+++ b/kubernetes/client/models/v1_config_map.py
@@ -183,6 +183,9 @@ class V1ConfigMap(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ConfigMap):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_config_map_env_source.py
+++ b/kubernetes/client/models/v1_config_map_env_source.py
@@ -131,6 +131,9 @@ class V1ConfigMapEnvSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ConfigMapEnvSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_config_map_key_selector.py
+++ b/kubernetes/client/models/v1_config_map_key_selector.py
@@ -159,6 +159,9 @@ class V1ConfigMapKeySelector(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ConfigMapKeySelector):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_config_map_list.py
+++ b/kubernetes/client/models/v1_config_map_list.py
@@ -185,6 +185,9 @@ class V1ConfigMapList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ConfigMapList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_config_map_projection.py
+++ b/kubernetes/client/models/v1_config_map_projection.py
@@ -157,6 +157,9 @@ class V1ConfigMapProjection(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ConfigMapProjection):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_config_map_volume_source.py
+++ b/kubernetes/client/models/v1_config_map_volume_source.py
@@ -183,6 +183,9 @@ class V1ConfigMapVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ConfigMapVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_container.py
+++ b/kubernetes/client/models/v1_container.py
@@ -601,6 +601,9 @@ class V1Container(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Container):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_container_image.py
+++ b/kubernetes/client/models/v1_container_image.py
@@ -133,6 +133,9 @@ class V1ContainerImage(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ContainerImage):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_container_port.py
+++ b/kubernetes/client/models/v1_container_port.py
@@ -211,6 +211,9 @@ class V1ContainerPort(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ContainerPort):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_container_state.py
+++ b/kubernetes/client/models/v1_container_state.py
@@ -157,6 +157,9 @@ class V1ContainerState(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ContainerState):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_container_state_running.py
+++ b/kubernetes/client/models/v1_container_state_running.py
@@ -105,6 +105,9 @@ class V1ContainerStateRunning(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ContainerStateRunning):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_container_state_terminated.py
+++ b/kubernetes/client/models/v1_container_state_terminated.py
@@ -263,6 +263,9 @@ class V1ContainerStateTerminated(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ContainerStateTerminated):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_container_state_waiting.py
+++ b/kubernetes/client/models/v1_container_state_waiting.py
@@ -131,6 +131,9 @@ class V1ContainerStateWaiting(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ContainerStateWaiting):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_container_status.py
+++ b/kubernetes/client/models/v1_container_status.py
@@ -297,6 +297,9 @@ class V1ContainerStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ContainerStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_cross_version_object_reference.py
+++ b/kubernetes/client/models/v1_cross_version_object_reference.py
@@ -161,6 +161,9 @@ class V1CrossVersionObjectReference(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1CrossVersionObjectReference):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_daemon_endpoint.py
+++ b/kubernetes/client/models/v1_daemon_endpoint.py
@@ -107,6 +107,9 @@ class V1DaemonEndpoint(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1DaemonEndpoint):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_delete_options.py
+++ b/kubernetes/client/models/v1_delete_options.py
@@ -235,6 +235,9 @@ class V1DeleteOptions(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1DeleteOptions):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_downward_api_projection.py
+++ b/kubernetes/client/models/v1_downward_api_projection.py
@@ -105,6 +105,9 @@ class V1DownwardAPIProjection(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1DownwardAPIProjection):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_downward_api_volume_file.py
+++ b/kubernetes/client/models/v1_downward_api_volume_file.py
@@ -185,6 +185,9 @@ class V1DownwardAPIVolumeFile(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1DownwardAPIVolumeFile):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_downward_api_volume_source.py
+++ b/kubernetes/client/models/v1_downward_api_volume_source.py
@@ -131,6 +131,9 @@ class V1DownwardAPIVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1DownwardAPIVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_empty_dir_volume_source.py
+++ b/kubernetes/client/models/v1_empty_dir_volume_source.py
@@ -105,6 +105,9 @@ class V1EmptyDirVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1EmptyDirVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_endpoint_address.py
+++ b/kubernetes/client/models/v1_endpoint_address.py
@@ -185,6 +185,9 @@ class V1EndpointAddress(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1EndpointAddress):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_endpoint_port.py
+++ b/kubernetes/client/models/v1_endpoint_port.py
@@ -159,6 +159,9 @@ class V1EndpointPort(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1EndpointPort):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_endpoint_subset.py
+++ b/kubernetes/client/models/v1_endpoint_subset.py
@@ -157,6 +157,9 @@ class V1EndpointSubset(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1EndpointSubset):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_endpoints.py
+++ b/kubernetes/client/models/v1_endpoints.py
@@ -185,6 +185,9 @@ class V1Endpoints(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Endpoints):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_endpoints_list.py
+++ b/kubernetes/client/models/v1_endpoints_list.py
@@ -185,6 +185,9 @@ class V1EndpointsList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1EndpointsList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_env_from_source.py
+++ b/kubernetes/client/models/v1_env_from_source.py
@@ -157,6 +157,9 @@ class V1EnvFromSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1EnvFromSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_env_var.py
+++ b/kubernetes/client/models/v1_env_var.py
@@ -159,6 +159,9 @@ class V1EnvVar(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1EnvVar):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_env_var_source.py
+++ b/kubernetes/client/models/v1_env_var_source.py
@@ -183,6 +183,9 @@ class V1EnvVarSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1EnvVarSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_event.py
+++ b/kubernetes/client/models/v1_event.py
@@ -369,6 +369,9 @@ class V1Event(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Event):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_event_list.py
+++ b/kubernetes/client/models/v1_event_list.py
@@ -185,6 +185,9 @@ class V1EventList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1EventList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_event_source.py
+++ b/kubernetes/client/models/v1_event_source.py
@@ -131,6 +131,9 @@ class V1EventSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1EventSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_exec_action.py
+++ b/kubernetes/client/models/v1_exec_action.py
@@ -105,6 +105,9 @@ class V1ExecAction(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ExecAction):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_fc_volume_source.py
+++ b/kubernetes/client/models/v1_fc_volume_source.py
@@ -187,6 +187,9 @@ class V1FCVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1FCVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_flex_volume_source.py
+++ b/kubernetes/client/models/v1_flex_volume_source.py
@@ -211,6 +211,9 @@ class V1FlexVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1FlexVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_flocker_volume_source.py
+++ b/kubernetes/client/models/v1_flocker_volume_source.py
@@ -131,6 +131,9 @@ class V1FlockerVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1FlockerVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_gce_persistent_disk_volume_source.py
+++ b/kubernetes/client/models/v1_gce_persistent_disk_volume_source.py
@@ -185,6 +185,9 @@ class V1GCEPersistentDiskVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1GCEPersistentDiskVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_git_repo_volume_source.py
+++ b/kubernetes/client/models/v1_git_repo_volume_source.py
@@ -159,6 +159,9 @@ class V1GitRepoVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1GitRepoVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_glusterfs_volume_source.py
+++ b/kubernetes/client/models/v1_glusterfs_volume_source.py
@@ -161,6 +161,9 @@ class V1GlusterfsVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1GlusterfsVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_group_version_for_discovery.py
+++ b/kubernetes/client/models/v1_group_version_for_discovery.py
@@ -135,6 +135,9 @@ class V1GroupVersionForDiscovery(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1GroupVersionForDiscovery):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_handler.py
+++ b/kubernetes/client/models/v1_handler.py
@@ -157,6 +157,9 @@ class V1Handler(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Handler):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_horizontal_pod_autoscaler.py
+++ b/kubernetes/client/models/v1_horizontal_pod_autoscaler.py
@@ -209,6 +209,9 @@ class V1HorizontalPodAutoscaler(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1HorizontalPodAutoscaler):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_horizontal_pod_autoscaler_list.py
+++ b/kubernetes/client/models/v1_horizontal_pod_autoscaler_list.py
@@ -185,6 +185,9 @@ class V1HorizontalPodAutoscalerList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1HorizontalPodAutoscalerList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_horizontal_pod_autoscaler_spec.py
+++ b/kubernetes/client/models/v1_horizontal_pod_autoscaler_spec.py
@@ -187,6 +187,9 @@ class V1HorizontalPodAutoscalerSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1HorizontalPodAutoscalerSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_horizontal_pod_autoscaler_status.py
+++ b/kubernetes/client/models/v1_horizontal_pod_autoscaler_status.py
@@ -213,6 +213,9 @@ class V1HorizontalPodAutoscalerStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1HorizontalPodAutoscalerStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_host_path_volume_source.py
+++ b/kubernetes/client/models/v1_host_path_volume_source.py
@@ -107,6 +107,9 @@ class V1HostPathVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1HostPathVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_http_get_action.py
+++ b/kubernetes/client/models/v1_http_get_action.py
@@ -211,6 +211,9 @@ class V1HTTPGetAction(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1HTTPGetAction):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_http_header.py
+++ b/kubernetes/client/models/v1_http_header.py
@@ -135,6 +135,9 @@ class V1HTTPHeader(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1HTTPHeader):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_iscsi_volume_source.py
+++ b/kubernetes/client/models/v1_iscsi_volume_source.py
@@ -267,6 +267,9 @@ class V1ISCSIVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ISCSIVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_job.py
+++ b/kubernetes/client/models/v1_job.py
@@ -209,6 +209,9 @@ class V1Job(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Job):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_job_condition.py
+++ b/kubernetes/client/models/v1_job_condition.py
@@ -239,6 +239,9 @@ class V1JobCondition(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1JobCondition):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_job_list.py
+++ b/kubernetes/client/models/v1_job_list.py
@@ -185,6 +185,9 @@ class V1JobList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1JobList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_job_spec.py
+++ b/kubernetes/client/models/v1_job_spec.py
@@ -237,6 +237,9 @@ class V1JobSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1JobSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_job_status.py
+++ b/kubernetes/client/models/v1_job_status.py
@@ -235,6 +235,9 @@ class V1JobStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1JobStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_key_to_path.py
+++ b/kubernetes/client/models/v1_key_to_path.py
@@ -161,6 +161,9 @@ class V1KeyToPath(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1KeyToPath):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_label_selector.py
+++ b/kubernetes/client/models/v1_label_selector.py
@@ -131,6 +131,9 @@ class V1LabelSelector(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1LabelSelector):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_label_selector_requirement.py
+++ b/kubernetes/client/models/v1_label_selector_requirement.py
@@ -161,6 +161,9 @@ class V1LabelSelectorRequirement(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1LabelSelectorRequirement):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_lifecycle.py
+++ b/kubernetes/client/models/v1_lifecycle.py
@@ -131,6 +131,9 @@ class V1Lifecycle(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Lifecycle):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_limit_range.py
+++ b/kubernetes/client/models/v1_limit_range.py
@@ -183,6 +183,9 @@ class V1LimitRange(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1LimitRange):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_limit_range_item.py
+++ b/kubernetes/client/models/v1_limit_range_item.py
@@ -235,6 +235,9 @@ class V1LimitRangeItem(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1LimitRangeItem):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_limit_range_list.py
+++ b/kubernetes/client/models/v1_limit_range_list.py
@@ -185,6 +185,9 @@ class V1LimitRangeList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1LimitRangeList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_limit_range_spec.py
+++ b/kubernetes/client/models/v1_limit_range_spec.py
@@ -107,6 +107,9 @@ class V1LimitRangeSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1LimitRangeSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_list_meta.py
+++ b/kubernetes/client/models/v1_list_meta.py
@@ -131,6 +131,9 @@ class V1ListMeta(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ListMeta):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_load_balancer_ingress.py
+++ b/kubernetes/client/models/v1_load_balancer_ingress.py
@@ -131,6 +131,9 @@ class V1LoadBalancerIngress(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1LoadBalancerIngress):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_load_balancer_status.py
+++ b/kubernetes/client/models/v1_load_balancer_status.py
@@ -105,6 +105,9 @@ class V1LoadBalancerStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1LoadBalancerStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_local_object_reference.py
+++ b/kubernetes/client/models/v1_local_object_reference.py
@@ -105,6 +105,9 @@ class V1LocalObjectReference(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1LocalObjectReference):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_local_subject_access_review.py
+++ b/kubernetes/client/models/v1_local_subject_access_review.py
@@ -209,6 +209,9 @@ class V1LocalSubjectAccessReview(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1LocalSubjectAccessReview):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_namespace.py
+++ b/kubernetes/client/models/v1_namespace.py
@@ -209,6 +209,9 @@ class V1Namespace(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Namespace):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_namespace_list.py
+++ b/kubernetes/client/models/v1_namespace_list.py
@@ -185,6 +185,9 @@ class V1NamespaceList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NamespaceList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_namespace_spec.py
+++ b/kubernetes/client/models/v1_namespace_spec.py
@@ -105,6 +105,9 @@ class V1NamespaceSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NamespaceSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_namespace_status.py
+++ b/kubernetes/client/models/v1_namespace_status.py
@@ -105,6 +105,9 @@ class V1NamespaceStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NamespaceStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_nfs_volume_source.py
+++ b/kubernetes/client/models/v1_nfs_volume_source.py
@@ -161,6 +161,9 @@ class V1NFSVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NFSVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_node.py
+++ b/kubernetes/client/models/v1_node.py
@@ -209,6 +209,9 @@ class V1Node(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Node):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_node_address.py
+++ b/kubernetes/client/models/v1_node_address.py
@@ -135,6 +135,9 @@ class V1NodeAddress(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NodeAddress):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_node_affinity.py
+++ b/kubernetes/client/models/v1_node_affinity.py
@@ -131,6 +131,9 @@ class V1NodeAffinity(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NodeAffinity):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_node_condition.py
+++ b/kubernetes/client/models/v1_node_condition.py
@@ -239,6 +239,9 @@ class V1NodeCondition(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NodeCondition):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_node_daemon_endpoints.py
+++ b/kubernetes/client/models/v1_node_daemon_endpoints.py
@@ -105,6 +105,9 @@ class V1NodeDaemonEndpoints(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NodeDaemonEndpoints):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_node_list.py
+++ b/kubernetes/client/models/v1_node_list.py
@@ -185,6 +185,9 @@ class V1NodeList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NodeList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_node_selector.py
+++ b/kubernetes/client/models/v1_node_selector.py
@@ -107,6 +107,9 @@ class V1NodeSelector(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NodeSelector):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_node_selector_requirement.py
+++ b/kubernetes/client/models/v1_node_selector_requirement.py
@@ -161,6 +161,9 @@ class V1NodeSelectorRequirement(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NodeSelectorRequirement):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_node_selector_term.py
+++ b/kubernetes/client/models/v1_node_selector_term.py
@@ -107,6 +107,9 @@ class V1NodeSelectorTerm(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NodeSelectorTerm):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_node_spec.py
+++ b/kubernetes/client/models/v1_node_spec.py
@@ -209,6 +209,9 @@ class V1NodeSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NodeSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_node_status.py
+++ b/kubernetes/client/models/v1_node_status.py
@@ -339,6 +339,9 @@ class V1NodeStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NodeStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_node_system_info.py
+++ b/kubernetes/client/models/v1_node_system_info.py
@@ -359,6 +359,9 @@ class V1NodeSystemInfo(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NodeSystemInfo):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_non_resource_attributes.py
+++ b/kubernetes/client/models/v1_non_resource_attributes.py
@@ -131,6 +131,9 @@ class V1NonResourceAttributes(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1NonResourceAttributes):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_object_field_selector.py
+++ b/kubernetes/client/models/v1_object_field_selector.py
@@ -133,6 +133,9 @@ class V1ObjectFieldSelector(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ObjectFieldSelector):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_object_meta.py
+++ b/kubernetes/client/models/v1_object_meta.py
@@ -469,6 +469,9 @@ class V1ObjectMeta(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ObjectMeta):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_object_reference.py
+++ b/kubernetes/client/models/v1_object_reference.py
@@ -261,6 +261,9 @@ class V1ObjectReference(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ObjectReference):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_owner_reference.py
+++ b/kubernetes/client/models/v1_owner_reference.py
@@ -243,6 +243,9 @@ class V1OwnerReference(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1OwnerReference):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_persistent_volume.py
+++ b/kubernetes/client/models/v1_persistent_volume.py
@@ -209,6 +209,9 @@ class V1PersistentVolume(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PersistentVolume):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_persistent_volume_claim.py
+++ b/kubernetes/client/models/v1_persistent_volume_claim.py
@@ -209,6 +209,9 @@ class V1PersistentVolumeClaim(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PersistentVolumeClaim):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_persistent_volume_claim_list.py
+++ b/kubernetes/client/models/v1_persistent_volume_claim_list.py
@@ -185,6 +185,9 @@ class V1PersistentVolumeClaimList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PersistentVolumeClaimList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_persistent_volume_claim_spec.py
+++ b/kubernetes/client/models/v1_persistent_volume_claim_spec.py
@@ -209,6 +209,9 @@ class V1PersistentVolumeClaimSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PersistentVolumeClaimSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_persistent_volume_claim_status.py
+++ b/kubernetes/client/models/v1_persistent_volume_claim_status.py
@@ -157,6 +157,9 @@ class V1PersistentVolumeClaimStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PersistentVolumeClaimStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_persistent_volume_claim_volume_source.py
+++ b/kubernetes/client/models/v1_persistent_volume_claim_volume_source.py
@@ -133,6 +133,9 @@ class V1PersistentVolumeClaimVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PersistentVolumeClaimVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_persistent_volume_list.py
+++ b/kubernetes/client/models/v1_persistent_volume_list.py
@@ -185,6 +185,9 @@ class V1PersistentVolumeList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PersistentVolumeList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_persistent_volume_spec.py
+++ b/kubernetes/client/models/v1_persistent_volume_spec.py
@@ -703,6 +703,9 @@ class V1PersistentVolumeSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PersistentVolumeSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_persistent_volume_status.py
+++ b/kubernetes/client/models/v1_persistent_volume_status.py
@@ -157,6 +157,9 @@ class V1PersistentVolumeStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PersistentVolumeStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_photon_persistent_disk_volume_source.py
+++ b/kubernetes/client/models/v1_photon_persistent_disk_volume_source.py
@@ -133,6 +133,9 @@ class V1PhotonPersistentDiskVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PhotonPersistentDiskVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_pod.py
+++ b/kubernetes/client/models/v1_pod.py
@@ -209,6 +209,9 @@ class V1Pod(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Pod):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_pod_affinity.py
+++ b/kubernetes/client/models/v1_pod_affinity.py
@@ -131,6 +131,9 @@ class V1PodAffinity(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PodAffinity):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_pod_affinity_term.py
+++ b/kubernetes/client/models/v1_pod_affinity_term.py
@@ -157,6 +157,9 @@ class V1PodAffinityTerm(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PodAffinityTerm):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_pod_anti_affinity.py
+++ b/kubernetes/client/models/v1_pod_anti_affinity.py
@@ -131,6 +131,9 @@ class V1PodAntiAffinity(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PodAntiAffinity):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_pod_condition.py
+++ b/kubernetes/client/models/v1_pod_condition.py
@@ -239,6 +239,9 @@ class V1PodCondition(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PodCondition):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_pod_list.py
+++ b/kubernetes/client/models/v1_pod_list.py
@@ -185,6 +185,9 @@ class V1PodList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PodList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_pod_security_context.py
+++ b/kubernetes/client/models/v1_pod_security_context.py
@@ -209,6 +209,9 @@ class V1PodSecurityContext(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PodSecurityContext):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_pod_spec.py
+++ b/kubernetes/client/models/v1_pod_spec.py
@@ -653,6 +653,9 @@ class V1PodSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PodSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_pod_status.py
+++ b/kubernetes/client/models/v1_pod_status.py
@@ -339,6 +339,9 @@ class V1PodStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PodStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_pod_template.py
+++ b/kubernetes/client/models/v1_pod_template.py
@@ -183,6 +183,9 @@ class V1PodTemplate(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PodTemplate):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_pod_template_list.py
+++ b/kubernetes/client/models/v1_pod_template_list.py
@@ -185,6 +185,9 @@ class V1PodTemplateList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PodTemplateList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_pod_template_spec.py
+++ b/kubernetes/client/models/v1_pod_template_spec.py
@@ -131,6 +131,9 @@ class V1PodTemplateSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PodTemplateSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_portworx_volume_source.py
+++ b/kubernetes/client/models/v1_portworx_volume_source.py
@@ -159,6 +159,9 @@ class V1PortworxVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PortworxVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_preconditions.py
+++ b/kubernetes/client/models/v1_preconditions.py
@@ -105,6 +105,9 @@ class V1Preconditions(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Preconditions):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_preferred_scheduling_term.py
+++ b/kubernetes/client/models/v1_preferred_scheduling_term.py
@@ -135,6 +135,9 @@ class V1PreferredSchedulingTerm(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1PreferredSchedulingTerm):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_probe.py
+++ b/kubernetes/client/models/v1_probe.py
@@ -287,6 +287,9 @@ class V1Probe(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Probe):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_projected_volume_source.py
+++ b/kubernetes/client/models/v1_projected_volume_source.py
@@ -133,6 +133,9 @@ class V1ProjectedVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ProjectedVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_quobyte_volume_source.py
+++ b/kubernetes/client/models/v1_quobyte_volume_source.py
@@ -213,6 +213,9 @@ class V1QuobyteVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1QuobyteVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_rbd_volume_source.py
+++ b/kubernetes/client/models/v1_rbd_volume_source.py
@@ -291,6 +291,9 @@ class V1RBDVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1RBDVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_replication_controller.py
+++ b/kubernetes/client/models/v1_replication_controller.py
@@ -209,6 +209,9 @@ class V1ReplicationController(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ReplicationController):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_replication_controller_condition.py
+++ b/kubernetes/client/models/v1_replication_controller_condition.py
@@ -213,6 +213,9 @@ class V1ReplicationControllerCondition(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ReplicationControllerCondition):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_replication_controller_list.py
+++ b/kubernetes/client/models/v1_replication_controller_list.py
@@ -185,6 +185,9 @@ class V1ReplicationControllerList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ReplicationControllerList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_replication_controller_spec.py
+++ b/kubernetes/client/models/v1_replication_controller_spec.py
@@ -183,6 +183,9 @@ class V1ReplicationControllerSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ReplicationControllerSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_replication_controller_status.py
+++ b/kubernetes/client/models/v1_replication_controller_status.py
@@ -237,6 +237,9 @@ class V1ReplicationControllerStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ReplicationControllerStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_resource_attributes.py
+++ b/kubernetes/client/models/v1_resource_attributes.py
@@ -261,6 +261,9 @@ class V1ResourceAttributes(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ResourceAttributes):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_resource_field_selector.py
+++ b/kubernetes/client/models/v1_resource_field_selector.py
@@ -159,6 +159,9 @@ class V1ResourceFieldSelector(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ResourceFieldSelector):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_resource_quota.py
+++ b/kubernetes/client/models/v1_resource_quota.py
@@ -209,6 +209,9 @@ class V1ResourceQuota(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ResourceQuota):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_resource_quota_list.py
+++ b/kubernetes/client/models/v1_resource_quota_list.py
@@ -185,6 +185,9 @@ class V1ResourceQuotaList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ResourceQuotaList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_resource_quota_spec.py
+++ b/kubernetes/client/models/v1_resource_quota_spec.py
@@ -131,6 +131,9 @@ class V1ResourceQuotaSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ResourceQuotaSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_resource_quota_status.py
+++ b/kubernetes/client/models/v1_resource_quota_status.py
@@ -131,6 +131,9 @@ class V1ResourceQuotaStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ResourceQuotaStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_resource_requirements.py
+++ b/kubernetes/client/models/v1_resource_requirements.py
@@ -131,6 +131,9 @@ class V1ResourceRequirements(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ResourceRequirements):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_scale.py
+++ b/kubernetes/client/models/v1_scale.py
@@ -209,6 +209,9 @@ class V1Scale(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Scale):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_scale_io_volume_source.py
+++ b/kubernetes/client/models/v1_scale_io_volume_source.py
@@ -345,6 +345,9 @@ class V1ScaleIOVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ScaleIOVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_scale_spec.py
+++ b/kubernetes/client/models/v1_scale_spec.py
@@ -105,6 +105,9 @@ class V1ScaleSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ScaleSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_scale_status.py
+++ b/kubernetes/client/models/v1_scale_status.py
@@ -133,6 +133,9 @@ class V1ScaleStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ScaleStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_se_linux_options.py
+++ b/kubernetes/client/models/v1_se_linux_options.py
@@ -183,6 +183,9 @@ class V1SELinuxOptions(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1SELinuxOptions):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_secret.py
+++ b/kubernetes/client/models/v1_secret.py
@@ -235,6 +235,9 @@ class V1Secret(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Secret):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_secret_env_source.py
+++ b/kubernetes/client/models/v1_secret_env_source.py
@@ -131,6 +131,9 @@ class V1SecretEnvSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1SecretEnvSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_secret_key_selector.py
+++ b/kubernetes/client/models/v1_secret_key_selector.py
@@ -159,6 +159,9 @@ class V1SecretKeySelector(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1SecretKeySelector):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_secret_list.py
+++ b/kubernetes/client/models/v1_secret_list.py
@@ -185,6 +185,9 @@ class V1SecretList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1SecretList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_secret_projection.py
+++ b/kubernetes/client/models/v1_secret_projection.py
@@ -157,6 +157,9 @@ class V1SecretProjection(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1SecretProjection):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_secret_volume_source.py
+++ b/kubernetes/client/models/v1_secret_volume_source.py
@@ -183,6 +183,9 @@ class V1SecretVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1SecretVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_security_context.py
+++ b/kubernetes/client/models/v1_security_context.py
@@ -235,6 +235,9 @@ class V1SecurityContext(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1SecurityContext):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_self_subject_access_review.py
+++ b/kubernetes/client/models/v1_self_subject_access_review.py
@@ -209,6 +209,9 @@ class V1SelfSubjectAccessReview(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1SelfSubjectAccessReview):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_self_subject_access_review_spec.py
+++ b/kubernetes/client/models/v1_self_subject_access_review_spec.py
@@ -131,6 +131,9 @@ class V1SelfSubjectAccessReviewSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1SelfSubjectAccessReviewSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_server_address_by_client_cidr.py
+++ b/kubernetes/client/models/v1_server_address_by_client_cidr.py
@@ -135,6 +135,9 @@ class V1ServerAddressByClientCIDR(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ServerAddressByClientCIDR):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_service.py
+++ b/kubernetes/client/models/v1_service.py
@@ -209,6 +209,9 @@ class V1Service(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Service):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_service_account.py
+++ b/kubernetes/client/models/v1_service_account.py
@@ -235,6 +235,9 @@ class V1ServiceAccount(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ServiceAccount):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_service_account_list.py
+++ b/kubernetes/client/models/v1_service_account_list.py
@@ -185,6 +185,9 @@ class V1ServiceAccountList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ServiceAccountList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_service_list.py
+++ b/kubernetes/client/models/v1_service_list.py
@@ -185,6 +185,9 @@ class V1ServiceList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ServiceList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_service_port.py
+++ b/kubernetes/client/models/v1_service_port.py
@@ -211,6 +211,9 @@ class V1ServicePort(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ServicePort):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_service_spec.py
+++ b/kubernetes/client/models/v1_service_spec.py
@@ -339,6 +339,9 @@ class V1ServiceSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ServiceSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_service_status.py
+++ b/kubernetes/client/models/v1_service_status.py
@@ -105,6 +105,9 @@ class V1ServiceStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1ServiceStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_status.py
+++ b/kubernetes/client/models/v1_status.py
@@ -287,6 +287,9 @@ class V1Status(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Status):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_status_cause.py
+++ b/kubernetes/client/models/v1_status_cause.py
@@ -157,6 +157,9 @@ class V1StatusCause(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1StatusCause):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_status_details.py
+++ b/kubernetes/client/models/v1_status_details.py
@@ -209,6 +209,9 @@ class V1StatusDetails(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1StatusDetails):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_storage_class.py
+++ b/kubernetes/client/models/v1_storage_class.py
@@ -211,6 +211,9 @@ class V1StorageClass(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1StorageClass):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_storage_class_list.py
+++ b/kubernetes/client/models/v1_storage_class_list.py
@@ -185,6 +185,9 @@ class V1StorageClassList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1StorageClassList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_subject_access_review.py
+++ b/kubernetes/client/models/v1_subject_access_review.py
@@ -209,6 +209,9 @@ class V1SubjectAccessReview(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1SubjectAccessReview):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_subject_access_review_spec.py
+++ b/kubernetes/client/models/v1_subject_access_review_spec.py
@@ -209,6 +209,9 @@ class V1SubjectAccessReviewSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1SubjectAccessReviewSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_subject_access_review_status.py
+++ b/kubernetes/client/models/v1_subject_access_review_status.py
@@ -159,6 +159,9 @@ class V1SubjectAccessReviewStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1SubjectAccessReviewStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_taint.py
+++ b/kubernetes/client/models/v1_taint.py
@@ -187,6 +187,9 @@ class V1Taint(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Taint):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_tcp_socket_action.py
+++ b/kubernetes/client/models/v1_tcp_socket_action.py
@@ -107,6 +107,9 @@ class V1TCPSocketAction(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1TCPSocketAction):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_token_review.py
+++ b/kubernetes/client/models/v1_token_review.py
@@ -209,6 +209,9 @@ class V1TokenReview(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1TokenReview):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_token_review_spec.py
+++ b/kubernetes/client/models/v1_token_review_spec.py
@@ -105,6 +105,9 @@ class V1TokenReviewSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1TokenReviewSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_token_review_status.py
+++ b/kubernetes/client/models/v1_token_review_status.py
@@ -157,6 +157,9 @@ class V1TokenReviewStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1TokenReviewStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_toleration.py
+++ b/kubernetes/client/models/v1_toleration.py
@@ -209,6 +209,9 @@ class V1Toleration(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Toleration):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_user_info.py
+++ b/kubernetes/client/models/v1_user_info.py
@@ -183,6 +183,9 @@ class V1UserInfo(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1UserInfo):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_volume.py
+++ b/kubernetes/client/models/v1_volume.py
@@ -783,6 +783,9 @@ class V1Volume(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1Volume):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_volume_mount.py
+++ b/kubernetes/client/models/v1_volume_mount.py
@@ -187,6 +187,9 @@ class V1VolumeMount(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1VolumeMount):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_volume_projection.py
+++ b/kubernetes/client/models/v1_volume_projection.py
@@ -157,6 +157,9 @@ class V1VolumeProjection(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1VolumeProjection):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_vsphere_virtual_disk_volume_source.py
+++ b/kubernetes/client/models/v1_vsphere_virtual_disk_volume_source.py
@@ -133,6 +133,9 @@ class V1VsphereVirtualDiskVolumeSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1VsphereVirtualDiskVolumeSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_watch_event.py
+++ b/kubernetes/client/models/v1_watch_event.py
@@ -133,6 +133,9 @@ class V1WatchEvent(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1WatchEvent):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1_weighted_pod_affinity_term.py
+++ b/kubernetes/client/models/v1_weighted_pod_affinity_term.py
@@ -135,6 +135,9 @@ class V1WeightedPodAffinityTerm(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1WeightedPodAffinityTerm):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1alpha1_cluster_role.py
+++ b/kubernetes/client/models/v1alpha1_cluster_role.py
@@ -185,6 +185,9 @@ class V1alpha1ClusterRole(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1alpha1ClusterRole):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1alpha1_cluster_role_binding.py
+++ b/kubernetes/client/models/v1alpha1_cluster_role_binding.py
@@ -213,6 +213,9 @@ class V1alpha1ClusterRoleBinding(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1alpha1ClusterRoleBinding):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1alpha1_cluster_role_binding_list.py
+++ b/kubernetes/client/models/v1alpha1_cluster_role_binding_list.py
@@ -185,6 +185,9 @@ class V1alpha1ClusterRoleBindingList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1alpha1ClusterRoleBindingList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1alpha1_cluster_role_list.py
+++ b/kubernetes/client/models/v1alpha1_cluster_role_list.py
@@ -185,6 +185,9 @@ class V1alpha1ClusterRoleList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1alpha1ClusterRoleList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1alpha1_pod_preset.py
+++ b/kubernetes/client/models/v1alpha1_pod_preset.py
@@ -179,6 +179,9 @@ class V1alpha1PodPreset(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1alpha1PodPreset):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1alpha1_pod_preset_list.py
+++ b/kubernetes/client/models/v1alpha1_pod_preset_list.py
@@ -185,6 +185,9 @@ class V1alpha1PodPresetList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1alpha1PodPresetList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1alpha1_pod_preset_spec.py
+++ b/kubernetes/client/models/v1alpha1_pod_preset_spec.py
@@ -209,6 +209,9 @@ class V1alpha1PodPresetSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1alpha1PodPresetSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1alpha1_policy_rule.py
+++ b/kubernetes/client/models/v1alpha1_policy_rule.py
@@ -211,6 +211,9 @@ class V1alpha1PolicyRule(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1alpha1PolicyRule):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1alpha1_role.py
+++ b/kubernetes/client/models/v1alpha1_role.py
@@ -185,6 +185,9 @@ class V1alpha1Role(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1alpha1Role):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1alpha1_role_binding.py
+++ b/kubernetes/client/models/v1alpha1_role_binding.py
@@ -213,6 +213,9 @@ class V1alpha1RoleBinding(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1alpha1RoleBinding):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1alpha1_role_binding_list.py
+++ b/kubernetes/client/models/v1alpha1_role_binding_list.py
@@ -185,6 +185,9 @@ class V1alpha1RoleBindingList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1alpha1RoleBindingList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1alpha1_role_list.py
+++ b/kubernetes/client/models/v1alpha1_role_list.py
@@ -185,6 +185,9 @@ class V1alpha1RoleList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1alpha1RoleList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1alpha1_role_ref.py
+++ b/kubernetes/client/models/v1alpha1_role_ref.py
@@ -163,6 +163,9 @@ class V1alpha1RoleRef(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1alpha1RoleRef):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1alpha1_subject.py
+++ b/kubernetes/client/models/v1alpha1_subject.py
@@ -187,6 +187,9 @@ class V1alpha1Subject(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1alpha1Subject):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_api_version.py
+++ b/kubernetes/client/models/v1beta1_api_version.py
@@ -105,6 +105,9 @@ class V1beta1APIVersion(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1APIVersion):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_certificate_signing_request.py
+++ b/kubernetes/client/models/v1beta1_certificate_signing_request.py
@@ -207,6 +207,9 @@ class V1beta1CertificateSigningRequest(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1CertificateSigningRequest):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_certificate_signing_request_condition.py
+++ b/kubernetes/client/models/v1beta1_certificate_signing_request_condition.py
@@ -185,6 +185,9 @@ class V1beta1CertificateSigningRequestCondition(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1CertificateSigningRequestCondition):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_certificate_signing_request_list.py
+++ b/kubernetes/client/models/v1beta1_certificate_signing_request_list.py
@@ -181,6 +181,9 @@ class V1beta1CertificateSigningRequestList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1CertificateSigningRequestList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_certificate_signing_request_spec.py
+++ b/kubernetes/client/models/v1beta1_certificate_signing_request_spec.py
@@ -237,6 +237,9 @@ class V1beta1CertificateSigningRequestSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1CertificateSigningRequestSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_certificate_signing_request_status.py
+++ b/kubernetes/client/models/v1beta1_certificate_signing_request_status.py
@@ -131,6 +131,9 @@ class V1beta1CertificateSigningRequestStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1CertificateSigningRequestStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_cluster_role.py
+++ b/kubernetes/client/models/v1beta1_cluster_role.py
@@ -185,6 +185,9 @@ class V1beta1ClusterRole(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1ClusterRole):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_cluster_role_binding.py
+++ b/kubernetes/client/models/v1beta1_cluster_role_binding.py
@@ -213,6 +213,9 @@ class V1beta1ClusterRoleBinding(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1ClusterRoleBinding):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_cluster_role_binding_list.py
+++ b/kubernetes/client/models/v1beta1_cluster_role_binding_list.py
@@ -185,6 +185,9 @@ class V1beta1ClusterRoleBindingList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1ClusterRoleBindingList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_cluster_role_list.py
+++ b/kubernetes/client/models/v1beta1_cluster_role_list.py
@@ -185,6 +185,9 @@ class V1beta1ClusterRoleList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1ClusterRoleList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_daemon_set.py
+++ b/kubernetes/client/models/v1beta1_daemon_set.py
@@ -209,6 +209,9 @@ class V1beta1DaemonSet(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1DaemonSet):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_daemon_set_list.py
+++ b/kubernetes/client/models/v1beta1_daemon_set_list.py
@@ -185,6 +185,9 @@ class V1beta1DaemonSetList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1DaemonSetList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_daemon_set_spec.py
+++ b/kubernetes/client/models/v1beta1_daemon_set_spec.py
@@ -211,6 +211,9 @@ class V1beta1DaemonSetSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1DaemonSetSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_daemon_set_status.py
+++ b/kubernetes/client/models/v1beta1_daemon_set_status.py
@@ -295,6 +295,9 @@ class V1beta1DaemonSetStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1DaemonSetStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_daemon_set_update_strategy.py
+++ b/kubernetes/client/models/v1beta1_daemon_set_update_strategy.py
@@ -131,6 +131,9 @@ class V1beta1DaemonSetUpdateStrategy(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1DaemonSetUpdateStrategy):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_eviction.py
+++ b/kubernetes/client/models/v1beta1_eviction.py
@@ -183,6 +183,9 @@ class V1beta1Eviction(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1Eviction):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_fs_group_strategy_options.py
+++ b/kubernetes/client/models/v1beta1_fs_group_strategy_options.py
@@ -131,6 +131,9 @@ class V1beta1FSGroupStrategyOptions(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1FSGroupStrategyOptions):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_host_port_range.py
+++ b/kubernetes/client/models/v1beta1_host_port_range.py
@@ -135,6 +135,9 @@ class V1beta1HostPortRange(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1HostPortRange):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_http_ingress_path.py
+++ b/kubernetes/client/models/v1beta1_http_ingress_path.py
@@ -133,6 +133,9 @@ class V1beta1HTTPIngressPath(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1HTTPIngressPath):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_http_ingress_rule_value.py
+++ b/kubernetes/client/models/v1beta1_http_ingress_rule_value.py
@@ -107,6 +107,9 @@ class V1beta1HTTPIngressRuleValue(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1HTTPIngressRuleValue):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_id_range.py
+++ b/kubernetes/client/models/v1beta1_id_range.py
@@ -135,6 +135,9 @@ class V1beta1IDRange(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1IDRange):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_ingress.py
+++ b/kubernetes/client/models/v1beta1_ingress.py
@@ -209,6 +209,9 @@ class V1beta1Ingress(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1Ingress):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_ingress_backend.py
+++ b/kubernetes/client/models/v1beta1_ingress_backend.py
@@ -135,6 +135,9 @@ class V1beta1IngressBackend(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1IngressBackend):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_ingress_list.py
+++ b/kubernetes/client/models/v1beta1_ingress_list.py
@@ -185,6 +185,9 @@ class V1beta1IngressList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1IngressList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_ingress_rule.py
+++ b/kubernetes/client/models/v1beta1_ingress_rule.py
@@ -129,6 +129,9 @@ class V1beta1IngressRule(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1IngressRule):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_ingress_spec.py
+++ b/kubernetes/client/models/v1beta1_ingress_spec.py
@@ -157,6 +157,9 @@ class V1beta1IngressSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1IngressSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_ingress_status.py
+++ b/kubernetes/client/models/v1beta1_ingress_status.py
@@ -105,6 +105,9 @@ class V1beta1IngressStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1IngressStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_ingress_tls.py
+++ b/kubernetes/client/models/v1beta1_ingress_tls.py
@@ -131,6 +131,9 @@ class V1beta1IngressTLS(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1IngressTLS):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_local_subject_access_review.py
+++ b/kubernetes/client/models/v1beta1_local_subject_access_review.py
@@ -209,6 +209,9 @@ class V1beta1LocalSubjectAccessReview(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1LocalSubjectAccessReview):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_network_policy.py
+++ b/kubernetes/client/models/v1beta1_network_policy.py
@@ -183,6 +183,9 @@ class V1beta1NetworkPolicy(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1NetworkPolicy):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_network_policy_ingress_rule.py
+++ b/kubernetes/client/models/v1beta1_network_policy_ingress_rule.py
@@ -131,6 +131,9 @@ class V1beta1NetworkPolicyIngressRule(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1NetworkPolicyIngressRule):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_network_policy_list.py
+++ b/kubernetes/client/models/v1beta1_network_policy_list.py
@@ -185,6 +185,9 @@ class V1beta1NetworkPolicyList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1NetworkPolicyList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_network_policy_peer.py
+++ b/kubernetes/client/models/v1beta1_network_policy_peer.py
@@ -131,6 +131,9 @@ class V1beta1NetworkPolicyPeer(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1NetworkPolicyPeer):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_network_policy_port.py
+++ b/kubernetes/client/models/v1beta1_network_policy_port.py
@@ -131,6 +131,9 @@ class V1beta1NetworkPolicyPort(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1NetworkPolicyPort):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_network_policy_spec.py
+++ b/kubernetes/client/models/v1beta1_network_policy_spec.py
@@ -133,6 +133,9 @@ class V1beta1NetworkPolicySpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1NetworkPolicySpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_non_resource_attributes.py
+++ b/kubernetes/client/models/v1beta1_non_resource_attributes.py
@@ -131,6 +131,9 @@ class V1beta1NonResourceAttributes(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1NonResourceAttributes):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_pod_disruption_budget.py
+++ b/kubernetes/client/models/v1beta1_pod_disruption_budget.py
@@ -207,6 +207,9 @@ class V1beta1PodDisruptionBudget(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1PodDisruptionBudget):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_pod_disruption_budget_list.py
+++ b/kubernetes/client/models/v1beta1_pod_disruption_budget_list.py
@@ -181,6 +181,9 @@ class V1beta1PodDisruptionBudgetList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1PodDisruptionBudgetList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_pod_disruption_budget_spec.py
+++ b/kubernetes/client/models/v1beta1_pod_disruption_budget_spec.py
@@ -131,6 +131,9 @@ class V1beta1PodDisruptionBudgetSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1PodDisruptionBudgetSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_pod_disruption_budget_status.py
+++ b/kubernetes/client/models/v1beta1_pod_disruption_budget_status.py
@@ -245,6 +245,9 @@ class V1beta1PodDisruptionBudgetStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1PodDisruptionBudgetStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_pod_security_policy.py
+++ b/kubernetes/client/models/v1beta1_pod_security_policy.py
@@ -183,6 +183,9 @@ class V1beta1PodSecurityPolicy(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1PodSecurityPolicy):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_pod_security_policy_list.py
+++ b/kubernetes/client/models/v1beta1_pod_security_policy_list.py
@@ -185,6 +185,9 @@ class V1beta1PodSecurityPolicyList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1PodSecurityPolicyList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_pod_security_policy_spec.py
+++ b/kubernetes/client/models/v1beta1_pod_security_policy_spec.py
@@ -451,6 +451,9 @@ class V1beta1PodSecurityPolicySpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1PodSecurityPolicySpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_policy_rule.py
+++ b/kubernetes/client/models/v1beta1_policy_rule.py
@@ -211,6 +211,9 @@ class V1beta1PolicyRule(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1PolicyRule):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_replica_set.py
+++ b/kubernetes/client/models/v1beta1_replica_set.py
@@ -209,6 +209,9 @@ class V1beta1ReplicaSet(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1ReplicaSet):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_replica_set_condition.py
+++ b/kubernetes/client/models/v1beta1_replica_set_condition.py
@@ -213,6 +213,9 @@ class V1beta1ReplicaSetCondition(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1ReplicaSetCondition):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_replica_set_list.py
+++ b/kubernetes/client/models/v1beta1_replica_set_list.py
@@ -185,6 +185,9 @@ class V1beta1ReplicaSetList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1ReplicaSetList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_replica_set_spec.py
+++ b/kubernetes/client/models/v1beta1_replica_set_spec.py
@@ -183,6 +183,9 @@ class V1beta1ReplicaSetSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1ReplicaSetSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_replica_set_status.py
+++ b/kubernetes/client/models/v1beta1_replica_set_status.py
@@ -237,6 +237,9 @@ class V1beta1ReplicaSetStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1ReplicaSetStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_resource_attributes.py
+++ b/kubernetes/client/models/v1beta1_resource_attributes.py
@@ -261,6 +261,9 @@ class V1beta1ResourceAttributes(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1ResourceAttributes):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_role.py
+++ b/kubernetes/client/models/v1beta1_role.py
@@ -185,6 +185,9 @@ class V1beta1Role(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1Role):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_role_binding.py
+++ b/kubernetes/client/models/v1beta1_role_binding.py
@@ -213,6 +213,9 @@ class V1beta1RoleBinding(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1RoleBinding):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_role_binding_list.py
+++ b/kubernetes/client/models/v1beta1_role_binding_list.py
@@ -185,6 +185,9 @@ class V1beta1RoleBindingList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1RoleBindingList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_role_list.py
+++ b/kubernetes/client/models/v1beta1_role_list.py
@@ -185,6 +185,9 @@ class V1beta1RoleList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1RoleList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_role_ref.py
+++ b/kubernetes/client/models/v1beta1_role_ref.py
@@ -163,6 +163,9 @@ class V1beta1RoleRef(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1RoleRef):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_rolling_update_daemon_set.py
+++ b/kubernetes/client/models/v1beta1_rolling_update_daemon_set.py
@@ -105,6 +105,9 @@ class V1beta1RollingUpdateDaemonSet(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1RollingUpdateDaemonSet):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_run_as_user_strategy_options.py
+++ b/kubernetes/client/models/v1beta1_run_as_user_strategy_options.py
@@ -133,6 +133,9 @@ class V1beta1RunAsUserStrategyOptions(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1RunAsUserStrategyOptions):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_se_linux_strategy_options.py
+++ b/kubernetes/client/models/v1beta1_se_linux_strategy_options.py
@@ -133,6 +133,9 @@ class V1beta1SELinuxStrategyOptions(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1SELinuxStrategyOptions):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_self_subject_access_review.py
+++ b/kubernetes/client/models/v1beta1_self_subject_access_review.py
@@ -209,6 +209,9 @@ class V1beta1SelfSubjectAccessReview(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1SelfSubjectAccessReview):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_self_subject_access_review_spec.py
+++ b/kubernetes/client/models/v1beta1_self_subject_access_review_spec.py
@@ -131,6 +131,9 @@ class V1beta1SelfSubjectAccessReviewSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1SelfSubjectAccessReviewSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_stateful_set.py
+++ b/kubernetes/client/models/v1beta1_stateful_set.py
@@ -207,6 +207,9 @@ class V1beta1StatefulSet(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1StatefulSet):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_stateful_set_list.py
+++ b/kubernetes/client/models/v1beta1_stateful_set_list.py
@@ -181,6 +181,9 @@ class V1beta1StatefulSetList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1StatefulSetList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_stateful_set_spec.py
+++ b/kubernetes/client/models/v1beta1_stateful_set_spec.py
@@ -213,6 +213,9 @@ class V1beta1StatefulSetSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1StatefulSetSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_stateful_set_status.py
+++ b/kubernetes/client/models/v1beta1_stateful_set_status.py
@@ -133,6 +133,9 @@ class V1beta1StatefulSetStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1StatefulSetStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_storage_class.py
+++ b/kubernetes/client/models/v1beta1_storage_class.py
@@ -211,6 +211,9 @@ class V1beta1StorageClass(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1StorageClass):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_storage_class_list.py
+++ b/kubernetes/client/models/v1beta1_storage_class_list.py
@@ -185,6 +185,9 @@ class V1beta1StorageClassList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1StorageClassList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_subject.py
+++ b/kubernetes/client/models/v1beta1_subject.py
@@ -187,6 +187,9 @@ class V1beta1Subject(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1Subject):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_subject_access_review.py
+++ b/kubernetes/client/models/v1beta1_subject_access_review.py
@@ -209,6 +209,9 @@ class V1beta1SubjectAccessReview(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1SubjectAccessReview):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_subject_access_review_spec.py
+++ b/kubernetes/client/models/v1beta1_subject_access_review_spec.py
@@ -209,6 +209,9 @@ class V1beta1SubjectAccessReviewSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1SubjectAccessReviewSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_subject_access_review_status.py
+++ b/kubernetes/client/models/v1beta1_subject_access_review_status.py
@@ -159,6 +159,9 @@ class V1beta1SubjectAccessReviewStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1SubjectAccessReviewStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_supplemental_groups_strategy_options.py
+++ b/kubernetes/client/models/v1beta1_supplemental_groups_strategy_options.py
@@ -131,6 +131,9 @@ class V1beta1SupplementalGroupsStrategyOptions(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1SupplementalGroupsStrategyOptions):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_third_party_resource.py
+++ b/kubernetes/client/models/v1beta1_third_party_resource.py
@@ -209,6 +209,9 @@ class V1beta1ThirdPartyResource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1ThirdPartyResource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_third_party_resource_list.py
+++ b/kubernetes/client/models/v1beta1_third_party_resource_list.py
@@ -185,6 +185,9 @@ class V1beta1ThirdPartyResourceList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1ThirdPartyResourceList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_token_review.py
+++ b/kubernetes/client/models/v1beta1_token_review.py
@@ -209,6 +209,9 @@ class V1beta1TokenReview(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1TokenReview):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_token_review_spec.py
+++ b/kubernetes/client/models/v1beta1_token_review_spec.py
@@ -105,6 +105,9 @@ class V1beta1TokenReviewSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1TokenReviewSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_token_review_status.py
+++ b/kubernetes/client/models/v1beta1_token_review_status.py
@@ -157,6 +157,9 @@ class V1beta1TokenReviewStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1TokenReviewStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v1beta1_user_info.py
+++ b/kubernetes/client/models/v1beta1_user_info.py
@@ -183,6 +183,9 @@ class V1beta1UserInfo(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V1beta1UserInfo):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_cron_job.py
+++ b/kubernetes/client/models/v2alpha1_cron_job.py
@@ -209,6 +209,9 @@ class V2alpha1CronJob(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1CronJob):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_cron_job_list.py
+++ b/kubernetes/client/models/v2alpha1_cron_job_list.py
@@ -185,6 +185,9 @@ class V2alpha1CronJobList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1CronJobList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_cron_job_spec.py
+++ b/kubernetes/client/models/v2alpha1_cron_job_spec.py
@@ -265,6 +265,9 @@ class V2alpha1CronJobSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1CronJobSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_cron_job_status.py
+++ b/kubernetes/client/models/v2alpha1_cron_job_status.py
@@ -131,6 +131,9 @@ class V2alpha1CronJobStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1CronJobStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_cross_version_object_reference.py
+++ b/kubernetes/client/models/v2alpha1_cross_version_object_reference.py
@@ -161,6 +161,9 @@ class V2alpha1CrossVersionObjectReference(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1CrossVersionObjectReference):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_horizontal_pod_autoscaler.py
+++ b/kubernetes/client/models/v2alpha1_horizontal_pod_autoscaler.py
@@ -209,6 +209,9 @@ class V2alpha1HorizontalPodAutoscaler(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1HorizontalPodAutoscaler):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_horizontal_pod_autoscaler_list.py
+++ b/kubernetes/client/models/v2alpha1_horizontal_pod_autoscaler_list.py
@@ -185,6 +185,9 @@ class V2alpha1HorizontalPodAutoscalerList(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1HorizontalPodAutoscalerList):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_horizontal_pod_autoscaler_spec.py
+++ b/kubernetes/client/models/v2alpha1_horizontal_pod_autoscaler_spec.py
@@ -187,6 +187,9 @@ class V2alpha1HorizontalPodAutoscalerSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1HorizontalPodAutoscalerSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_horizontal_pod_autoscaler_status.py
+++ b/kubernetes/client/models/v2alpha1_horizontal_pod_autoscaler_status.py
@@ -215,6 +215,9 @@ class V2alpha1HorizontalPodAutoscalerStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1HorizontalPodAutoscalerStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_job_template_spec.py
+++ b/kubernetes/client/models/v2alpha1_job_template_spec.py
@@ -131,6 +131,9 @@ class V2alpha1JobTemplateSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1JobTemplateSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_metric_spec.py
+++ b/kubernetes/client/models/v2alpha1_metric_spec.py
@@ -185,6 +185,9 @@ class V2alpha1MetricSpec(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1MetricSpec):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_metric_status.py
+++ b/kubernetes/client/models/v2alpha1_metric_status.py
@@ -185,6 +185,9 @@ class V2alpha1MetricStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1MetricStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_object_metric_source.py
+++ b/kubernetes/client/models/v2alpha1_object_metric_source.py
@@ -163,6 +163,9 @@ class V2alpha1ObjectMetricSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1ObjectMetricSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_object_metric_status.py
+++ b/kubernetes/client/models/v2alpha1_object_metric_status.py
@@ -163,6 +163,9 @@ class V2alpha1ObjectMetricStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1ObjectMetricStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_pods_metric_source.py
+++ b/kubernetes/client/models/v2alpha1_pods_metric_source.py
@@ -135,6 +135,9 @@ class V2alpha1PodsMetricSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1PodsMetricSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_pods_metric_status.py
+++ b/kubernetes/client/models/v2alpha1_pods_metric_status.py
@@ -135,6 +135,9 @@ class V2alpha1PodsMetricStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1PodsMetricStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_resource_metric_source.py
+++ b/kubernetes/client/models/v2alpha1_resource_metric_source.py
@@ -159,6 +159,9 @@ class V2alpha1ResourceMetricSource(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1ResourceMetricSource):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/v2alpha1_resource_metric_status.py
+++ b/kubernetes/client/models/v2alpha1_resource_metric_status.py
@@ -161,6 +161,9 @@ class V2alpha1ResourceMetricStatus(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, V2alpha1ResourceMetricStatus):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/kubernetes/client/models/version_info.py
+++ b/kubernetes/client/models/version_info.py
@@ -313,6 +313,9 @@ class VersionInfo(object):
         """
         Returns true if both objects are equal
         """
+        if not isinstance(other, VersionInfo):
+            return False
+
         return self.__dict__ == other.__dict__
 
     def __ne__(self, other):

--- a/scripts/pom.xml
+++ b/scripts/pom.xml
@@ -10,7 +10,7 @@
             <plugin>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-codegen-maven-plugin</artifactId>
-                <version>2.2.2-SNAPSHOT</version>
+                <version>2.2.2</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
We were relying on an snapshot version of swagger codegen because of the fix we applied there. Now that 2.2.2 is released and has all of our fixes, we can switch to the stable version.