### PR TITLE
Fix invalid CA cert used by websocket lib (#262)

### DIFF
--- a/kubernetes/client/ws_client.py
+++ b/kubernetes/client/ws_client.py
@@ -16,7 +16,9 @@ import select
 import certifi
 import time
 import collections
+from distutils.version import StrictVersion
 from websocket import WebSocket, ABNF, enableTrace
+from websocket import __version__ as websocket_version
 import six
 import ssl
 from six.moves.urllib.parse import urlencode, quote_plus, urlparse, urlunparse
@@ -51,8 +53,11 @@ class WSClient:
                 'cert_reqs': ssl.CERT_REQUIRED,
                 'keyfile': configuration.key_file,
                 'certfile': configuration.cert_file,
-                'ca_certs': configuration.ssl_ca_cert or certifi.where(),
+                'ca_cert': configuration.ssl_ca_cert or certifi.where(),
             }
+            if StrictVersion(websocket_version) < StrictVersion('0.41.0'):
+                ssl_opts['ca_certs'] = ssl_opts.pop('ca_cert')
+
             if configuration.assert_hostname is not None:
                 ssl_opts['check_hostname'] = configuration.assert_hostname
         else:


### PR DESCRIPTION
The following change in upstream websocket-client changed the ssl
options interface by renaming the configuration key from "ca_certs" to
"ca_cert": https://goo.gl/cxSrXt

Since version 0.41.0 of the websocket library it was no longer possible
to stream the pod logs via the kubernetes python library. Reason being
that the websocket client library (project dependency) was falling back
on the platform default SSL bundle, which does not include the required
kubernetes ca cert. Consequently python's ssl library raised a
CERTIFICATE_VERIFY_FAILED error when trying to talk to the API.

This commit adds handling for both cases, meaning now both the older
configuration key-name and the new are supported, ensuring the proper
cert propagates to the websocket client. Thus avoiding requiring a
lower bound version bump on the required websocket client library
version. The associated unit test also verifies that the cert reaches
python's native SSL code as intended, to guard against future
regressions of this sort.