### PR TITLE
Use oauth2 from google-auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ setuptools>=21.0.0  # PSF/ZPL
 urllib3>=1.19.1,!=1.21  # MIT
 pyyaml>=3.12  # MIT
 oauth2client>=4.0.0  # Apache-2.0
+google-auth>=1.0.1  # Apache-2.0
 ipaddress>=1.0.17  # PSF
 websocket-client>=0.32.0 # LGPLv2+


### PR DESCRIPTION
oauth2client is deprecated [1], use google-auth.

[1] https://github.com/google/oauth2client/releases (see Note)

Closes: #275

Signed-off-by: Spyros Trigazis <spyridon.trigazis@cern.ch>