### PR TITLE
Use py.test instead of nosetests for better problem reporting

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 coverage>=4.0.3
 nose>=1.3.7
+pytest
 pluggy>=0.3.1
 py>=1.4.31
 randomize>=0.13

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps = -r{toxinidir}/test-requirements.txt
        -r{toxinidir}/requirements.txt
 commands =
    python -V
-   nosetests -e e2e -v
+   py.test -vvv -s --ignore=kubernetes/e2e_test
 
 [testenv:docs]
 commands =
@@ -22,17 +22,17 @@ commands =
 [testenv:py27-functional]
 commands =
    python -V
-   {toxinidir}/scripts/kube-init.sh nosetests -v []
+   {toxinidir}/scripts/kube-init.sh py.test -vvv -s []
 
 [testenv:py35-functional]
 commands =
    python -V
-   {toxinidir}/scripts/kube-init.sh nosetests -v []
+   {toxinidir}/scripts/kube-init.sh py.test -vvv -s []
 
 [testenv:py36-functional]
 commands =
    python -V
-   {toxinidir}/scripts/kube-init.sh nosetests -v []
+   {toxinidir}/scripts/kube-init.sh py.test -vvv -s []
 
 [testenv:coverage]
 commands =


### PR DESCRIPTION
nosetests output is not very useful for diagnosing issues when
running in travis. Let us switch to py.test