### PR TITLE
Remove oauth2client requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ python-dateutil>=2.5.3  # BSD
 setuptools>=21.0.0  # PSF/ZPL
 urllib3>=1.19.1,!=1.21  # MIT
 pyyaml>=3.12  # MIT
-oauth2client>=4.0.0  # Apache-2.0
 google-auth>=1.0.1  # Apache-2.0
 ipaddress>=1.0.17  # PSF
 websocket-client>=0.32.0 # LGPLv2+


### PR DESCRIPTION
In #278 google-auth was added in requirements and in [1]
python-base stopped using it.

Remove oauth2client requirement and update submodule commit.

[1] https://github.com/kubernetes-client/python-base/pull/16

Related-Issue: #275

Signed-off-by: Spyros Trigazis <spyridon.trigazis@cern.ch>