### PR TITLE
Amendment to PR 270 (issue #262)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ urllib3>=1.19.1,!=1.21  # MIT
 pyyaml>=3.12  # MIT
 google-auth>=1.0.1  # Apache-2.0
 ipaddress>=1.0.17  # PSF
-websocket-client<=0.40.0 # LGPLv2+
+websocket-client>=0.32.0,<=0.40.0 # LGPLv2+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ urllib3>=1.19.1,!=1.21  # MIT
 pyyaml>=3.12  # MIT
 google-auth>=1.0.1  # Apache-2.0
 ipaddress>=1.0.17  # PSF
-websocket-client>=0.32.0 # LGPLv2+
+websocket-client<=0.40.0 # LGPLv2+


### PR DESCRIPTION
The issue surround #262 which was fixed in version 0.43 of websocket-client, has been reintroduced in version 0.44.0

This PR updates the requirements so websocket-client will go no further than 0.40.0