### PR TITLE
make sure that kubernetes.stream module gets installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     tests_require=TESTS_REQUIRES,
     packages=['kubernetes', 'kubernetes.client', 'kubernetes.config',
               'kubernetes.watch', 'kubernetes.client.apis',
-              'kubernetes.client.models'],
+              'kubernetes.client.models', 'kubernetes.stream'],
     include_package_data=True,
     long_description="""\
     Python client for kubernetes http://kubernetes.io/


### PR DESCRIPTION
Previously, installing the client using `python setup.py install`
would fail to install the `kubernetes.stream` module, leading to
errors when trying to `import kubernetes`.

Closes #355