### PR TITLE
Add files in root directory to dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include LICENSE
+include OWNERS
+include *.md
+include *.txt
+include *.ini
+exclude .gitignore
+exclude .gitreview
+
+global-exclude *.pyc


### PR DESCRIPTION
By adding a MANIFEST.in, we can list the files we need to include
into the tgz when we run "python setup.py sdist". With this change
you should see the following files in the tgz file.

LICENSE
MANIFEST.in
OWNERS
PKG-INFO
README.md
RELEASE.md
requirements.txt
setup.cfg
setup.py
test-requirements.txt
tox.ini

Fixes #361