### PR TITLE
Ignore trailing slashes for server url

### DIFF
--- a/kubernetes/client/api_client.py
+++ b/kubernetes/client/api_client.py
@@ -144,7 +144,8 @@ class ApiClient(object):
             body = self.sanitize_for_serialization(body)
 
         # request url
-        url = self.configuration.host + resource_path
+        # ignore trailing slashes in base url
+        url = self.configuration.host.rstrip('/') + resource_path
 
         # perform request and return response
         response_data = self.request(method, url,


### PR DESCRIPTION
`kubectl` by default ignores trailing slashes for server url, but python client isn't. For example if you have server URL like this: `https://kubernetes.example:8443/` (with trailing slash), kubectl will work, but python client will fail with `kubernetes.client.rest.ApiException: (404)`.

I think it's nice to have consistent behavior across all clients.