### PR TITLE
make websocket-client dependency more open

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ urllib3>=1.19.1,!=1.21  # MIT
 pyyaml>=3.12  # MIT
 google-auth>=1.0.1  # Apache-2.0
 ipaddress>=1.0.17  # PSF
-websocket-client>=0.32.0,<=0.40.0 # LGPLv2+
+websocket-client>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.* # LGPLv2+
 requests # Apache-2.0
 requests-oauthlib # ISC


### PR DESCRIPTION
fixes: https://github.com/kubernetes-incubator/client-python/issues/413

The issue as reported in https://github.com/kubernetes-incubator/client-python/issues/262
was not reproduced in versions of websocketclient over 0.40.0, so just mask
0.40.0.  This allows consumption of possible security fixes and allows the
client to be co-installable with more python libraries.