### PR TITLE
Correct example of delete_namespaced_deployment

### DIFF
--- a/kubernetes/docs/ExtensionsV1beta1Api.md
+++ b/kubernetes/docs/ExtensionsV1beta1Api.md
@@ -989,14 +989,16 @@ configuration.api_key['authorization'] = 'YOUR_API_KEY'
 api_instance = kubernetes.client.ExtensionsV1beta1Api(kubernetes.client.ApiClient(configuration))
 name = 'name_example' # str | name of the Deployment
 namespace = 'namespace_example' # str | object name and auth scope, such as for teams and projects
-body = kubernetes.client.V1DeleteOptions() # V1DeleteOptions | 
-pretty = 'pretty_example' # str | If 'true', then the output is pretty printed. (optional)
 grace_period_seconds = 56 # int | The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately. (optional)
-orphan_dependents = true # bool | Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. (optional)
-propagation_policy = 'propagation_policy_example' # str | Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. (optional)
+propagation_policy = 'propagation_policy_example' # str | Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy.  Example values: "Foreground", "Background", "Orphan" (optional)
+body = kubernetes.client.V1DeleteOptions(
+  grace_period_seconds=grace_period_seconds,
+  propagation_policy=propagation_policy
+)
+pretty = 'pretty_example' # str | If 'true', then the output is pretty printed. (optional)
 
 try: 
-    api_response = api_instance.delete_namespaced_deployment(name, namespace, body, pretty=pretty, grace_period_seconds=grace_period_seconds, orphan_dependents=orphan_dependents, propagation_policy=propagation_policy)
+    api_response = api_instance.delete_namespaced_deployment(name, namespace, body, pretty=pretty)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling ExtensionsV1beta1Api->delete_namespaced_deployment: %s\n" % e)


### PR DESCRIPTION
grace_period_seconds, orpan_descendants, and propagation_policy are part of the V1DeleteOptions body parameter.  Body is a required parameter, and if it is empty and prop. policy is set then prop policy is ignored, resulting in orphans.  If prop policy is set in the body then orphans are removed as expected.  Replaced example code with working code.